### PR TITLE
Implement reload when props change.

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "hoist-non-react-statics": "^2.3.1",
     "immutable": "^3.8.1",
     "prop-types": "^15.5.10",
-    "react": "^15.6.1"
+    "react": "^16.0.0"
   },
   "devDependencies": {
     "babel-jest": "^21.0.2",
@@ -39,8 +39,8 @@
     "jest": "^21.1.0",
     "jest-nyan-reporter": "https://github.com/BurningLutz/jest-nyan-reporter",
     "prop-types": "^15.5.10",
-    "react": "^15.6.1",
-    "react-dom": "^15.6.2",
+    "react": "^16.0.0",
+    "react-dom": "^16.0.0",
     "react-redux": "^5.0.6",
     "redux": "^3.7.2",
     "redux-thunk": "^2.2.0"

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "react": "^16.0.0",
     "react-dom": "^16.0.0",
     "react-redux": "^5.0.6",
+    "react-test-renderer": "^16.0.0",
     "redux": "^3.7.2",
     "redux-thunk": "^2.2.0"
   },

--- a/src/Initable.jsx
+++ b/src/Initable.jsx
@@ -4,19 +4,27 @@ import hoistStatics from 'hoist-non-react-statics'
 
 import getDisplayName from './getDisplayName'
 
-function Initable({ loadFn, loadingFn, resetFn }) {
+function Initable({ loadFn, loadingFn, resetFn, reloadFn }) {
   return function (WrappedComponent) {
     const connectDisplayName = `Initable(${getDisplayName(WrappedComponent)})`
     class Initable extends PureComponent {
+      _store = this.context.store
+
       componentDidMount() {
-        const store = this.context.store
-        store.dispatch(loadFn(store.getState(), this.props))
-        this.subscriber = store.subscribe(this.onChangeState)
+        this._store.dispatch(loadFn(this._store.getState(), this.props))
+        this.subscriber = this._store.subscribe(this.onChangeState)
       }
       componentWillUnmount() {
-        const store = this.context.store
-        resetFn && store.dispatch(resetFn(store.getState(), this.props))
+        resetFn && this._store.dispatch(resetFn(this._store.getState(), this.props))
         this.subscriber()
+      }
+      componentWillReceiveProps(props) {
+        if (reloadFn) {
+          this._store.dispatch(reloadFn(this._store.getState(), this.props, props))
+        } else {
+          this._store.dispatch(resetFn(this._store.getState(), this.props))
+          this._store.dispatch(loadFn(this._store.getState(), props))
+        }
       }
 
       onChangeState = () => {
@@ -24,7 +32,7 @@ function Initable({ loadFn, loadingFn, resetFn }) {
       }
 
       render() {
-        return !loadingFn(this.context.store.getState(), this.props) && createElement(WrappedComponent, this.props)
+        return !loadingFn(this._store.getState(), this.props) && createElement(WrappedComponent, this.props)
       }
     }
 

--- a/src/Initable.jsx
+++ b/src/Initable.jsx
@@ -10,11 +10,12 @@ function Initable({ loadFn, loadingFn, resetFn }) {
     class Initable extends PureComponent {
       componentDidMount() {
         const store = this.context.store
-        store.dispatch(loadFn())
+        store.dispatch(loadFn(store.getState(), this.props))
         this.subscriber = store.subscribe(this.onChangeState)
       }
       componentWillUnmount() {
-        resetFn && this.context.store.dispatch(resetFn())
+        const store = this.context.store
+        resetFn && store.dispatch(resetFn(store.getState(), this.props))
         this.subscriber()
       }
 

--- a/test/initable.test.js
+++ b/test/initable.test.js
@@ -109,3 +109,60 @@ test('it should call resetFn with state and props as args when unmount', () => {
 
   expect(resetFn).toBeCalledWith(store.getState(), props)
 })
+
+test('it should call resetFn & loadFn in order if reloadFn is not provided when received new props', () => {
+  const store = createDummyStore()
+  const loadFn = jest.fn(() => ({ type: 'LOAD' }))
+  const resetFn = jest.fn(() => ({ type: 'RESET' }))
+  const wrapper1 = Initable({
+    loadFn,
+    loadingFn: () => false,
+    resetFn,
+  })
+  const Wrapped1 = wrapper1(Foo)
+
+  const oldProps = { id: 1 }
+  const newProps = { id: 2 }
+
+  const renderer = TR.create(
+    <Provider store={store}>
+      <Wrapped1 {...oldProps} />
+    </Provider>
+  )
+  renderer.update(
+    <Provider store={store}>
+      <Wrapped1 {...newProps} />
+    </Provider>
+  )
+
+  expect(resetFn).toBeCalledWith(store.getState(), oldProps)
+  expect(loadFn).toBeCalledWith(store.getState(), newProps)
+})
+
+test('it should call reloadFn if provided when received new props', () => {
+  const store = createDummyStore()
+  const reloadFn = jest.fn(() => ({ type: 'RELOAD' }))
+  const wrapper1 = Initable({
+    loadFn: () => ({ type: 'LOAD' }),
+    loadingFn: () => false,
+    resetFn: () => ({ type: 'RESET' }),
+    reloadFn,
+  })
+  const Wrapped1 = wrapper1(Foo)
+
+  const oldProps = { id: 1 }
+  const newProps = { id: 2 }
+
+  const renderer = TR.create(
+    <Provider store={store}>
+      <Wrapped1 {...oldProps} />
+    </Provider>
+  )
+  renderer.update(
+    <Provider store={store}>
+      <Wrapped1 {...newProps} />
+    </Provider>
+  )
+
+  expect(reloadFn).toBeCalledWith(store.getState(), oldProps, newProps)
+})

--- a/test/initable.test.js
+++ b/test/initable.test.js
@@ -1,5 +1,6 @@
 import React from 'react'
 import TU from 'react-dom/test-utils'
+import TR from 'react-test-renderer'
 import { Provider } from 'react-redux'
 import { createStore } from 'redux'
 
@@ -22,33 +23,27 @@ const Wrapped = wrapper(Foo)
 test('it should render null when loading', () => {
   const store = createDummyStore({ loading: true })
 
-  const tree = TU.renderIntoDocument(
+  const renderer = TR.create(
     <Provider store={store}>
       <Wrapped />
     </Provider>
   )
-  const testee = TU.findRenderedComponentWithType(
-    tree,
-    Wrapped
-  )
+  const elem = renderer.root.findByType(Wrapped).instance
 
-  expect(testee.render()).toBeFalsy()
+  expect(elem.render()).toBeFalsy()
 })
 
 test('it should render component when not loading', () => {
   const store = createDummyStore({ loading: false })
 
-  const tree = TU.renderIntoDocument(
+  const renderer = TR.create(
     <Provider store={store}>
       <Wrapped />
     </Provider>
   )
-  const testee = TU.findRenderedComponentWithType(
-    tree,
-    Wrapped
-  )
+  const elem = renderer.root.findByType(Wrapped).instance
 
-  expect(TU.isElementOfType(testee.render(), Foo)).toBeTruthy()
+  expect(TU.isElementOfType(elem.render(), Foo)).toBeTruthy()
 })
 
 test('it should call loadFn with state and props as args when mounted', () => {
@@ -63,7 +58,7 @@ test('it should call loadFn with state and props as args when mounted', () => {
 
   const props = { id: 1 }
 
-  TU.renderIntoDocument(
+  TR.create(
     <Provider store={store}>
       <Wrapped1 {...props} />
     </Provider>
@@ -84,7 +79,7 @@ test('it should call loadingFn with state and props as args when rendered', () =
 
   const props = { id: 1 }
 
-  TU.renderIntoDocument(
+  TR.create(
     <Provider store={store}>
       <Wrapped1 {...props} />
     </Provider>
@@ -105,14 +100,12 @@ test('it should call resetFn with state and props as args when unmount', () => {
 
   const props = { id: 1 }
 
-  let wrappedRef
-
-  TU.renderIntoDocument(
+  const renderer = TR.create(
     <Provider store={store}>
-      <Wrapped1 ref={(ref) => wrappedRef = ref} {...props} />
+      <Wrapped1 {...props} />
     </Provider>
   )
-  wrappedRef.componentWillUnmount()
+  renderer.unmount()
 
   expect(resetFn).toBeCalledWith(store.getState(), props)
 })

--- a/yarn.lock
+++ b/yarn.lock
@@ -960,14 +960,6 @@ core-util-is@1.0.2, core-util-is@~1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/core-util-is/-/core-util-is-1.0.2.tgz#b5fd54220aa2bc5ab57aab7140c940754503c1a7"
 
-create-react-class@^15.6.0:
-  version "15.6.0"
-  resolved "https://registry.yarnpkg.com/create-react-class/-/create-react-class-15.6.0.tgz#ab448497c26566e1e29413e883207d57cfe7bed4"
-  dependencies:
-    fbjs "^0.8.9"
-    loose-envify "^1.3.1"
-    object-assign "^4.1.1"
-
 cross-spawn@^5.0.1:
   version "5.1.0"
   resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-5.1.0.tgz#e8bd0efee58fcff6f8f94510a0a554bbfa235449"
@@ -1202,6 +1194,18 @@ fb-watchman@^2.0.0:
   resolved "https://registry.yarnpkg.com/fb-watchman/-/fb-watchman-2.0.0.tgz#54e9abf7dfa2f26cd9b1636c588c1afc05de5d58"
   dependencies:
     bser "^2.0.0"
+
+fbjs@^0.8.16:
+  version "0.8.16"
+  resolved "https://registry.yarnpkg.com/fbjs/-/fbjs-0.8.16.tgz#5e67432f550dc41b572bf55847b8aca64e5337db"
+  dependencies:
+    core-js "^1.0.0"
+    isomorphic-fetch "^2.1.1"
+    loose-envify "^1.0.0"
+    object-assign "^4.1.0"
+    promise "^7.1.1"
+    setimmediate "^1.0.5"
+    ua-parser-js "^0.7.9"
 
 fbjs@^0.8.9:
   version "0.8.15"
@@ -2469,6 +2473,14 @@ prop-types@^15.5.10:
     fbjs "^0.8.9"
     loose-envify "^1.3.1"
 
+prop-types@^15.6.0:
+  version "15.6.0"
+  resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.6.0.tgz#ceaf083022fc46b4a35f69e13ef75aed0d639856"
+  dependencies:
+    fbjs "^0.8.16"
+    loose-envify "^1.3.1"
+    object-assign "^4.1.1"
+
 prr@~0.0.0:
   version "0.0.0"
   resolved "https://registry.yarnpkg.com/prr/-/prr-0.0.0.tgz#1a84b85908325501411853d0081ee3fa86e2926a"
@@ -2501,14 +2513,14 @@ rc@^1.1.7:
     minimist "^1.2.0"
     strip-json-comments "~2.0.1"
 
-react-dom@^15.6.2:
-  version "15.6.2"
-  resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-15.6.2.tgz#41cfadf693b757faf2708443a1d1fd5a02bef730"
+react-dom@^16.0.0:
+  version "16.0.0"
+  resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-16.0.0.tgz#9cc3079c3dcd70d4c6e01b84aab2a7e34c303f58"
   dependencies:
-    fbjs "^0.8.9"
+    fbjs "^0.8.16"
     loose-envify "^1.1.0"
-    object-assign "^4.1.0"
-    prop-types "^15.5.10"
+    object-assign "^4.1.1"
+    prop-types "^15.6.0"
 
 react-redux@^5.0.6:
   version "5.0.6"
@@ -2521,15 +2533,14 @@ react-redux@^5.0.6:
     loose-envify "^1.1.0"
     prop-types "^15.5.10"
 
-react@^15.6.1:
-  version "15.6.1"
-  resolved "https://registry.yarnpkg.com/react/-/react-15.6.1.tgz#baa8434ec6780bde997cdc380b79cd33b96393df"
+react@^16.0.0:
+  version "16.0.0"
+  resolved "https://registry.yarnpkg.com/react/-/react-16.0.0.tgz#ce7df8f1941b036f02b2cca9dbd0cb1f0e855e2d"
   dependencies:
-    create-react-class "^15.6.0"
-    fbjs "^0.8.9"
+    fbjs "^0.8.16"
     loose-envify "^1.1.0"
-    object-assign "^4.1.0"
-    prop-types "^15.5.10"
+    object-assign "^4.1.1"
+    prop-types "^15.6.0"
 
 read-pkg-up@^1.0.1:
   version "1.0.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2533,6 +2533,13 @@ react-redux@^5.0.6:
     loose-envify "^1.1.0"
     prop-types "^15.5.10"
 
+react-test-renderer@^16.0.0:
+  version "16.0.0"
+  resolved "https://registry.yarnpkg.com/react-test-renderer/-/react-test-renderer-16.0.0.tgz#9fe7b8308f2f71f29fc356d4102086f131c9cb15"
+  dependencies:
+    fbjs "^0.8.16"
+    object-assign "^4.1.1"
+
 react@^16.0.0:
   version "16.0.0"
   resolved "https://registry.yarnpkg.com/react/-/react-16.0.0.tgz#ce7df8f1941b036f02b2cca9dbd0cb1f0e855e2d"


### PR DESCRIPTION
This is done by two strategies:
1. if `reloadFn` is provided, `Initiable` will call it with `(state, oldProps, newProps)` so we can do cleanup and fetch new data in one step.
2. if not provided, it will call `resetFn` first with `(state, oldProps)`, and then call `loadFn` with `(state, newProps)` to simulate a reload.

And we aslo upgrade dependencies of react & react-dom to 16.0.0