### PR TITLE
fixed reload and rerender issue

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,5 +61,8 @@
     "reporters": [
       "jest-nyan-reporter"
     ]
+  },
+  "dependencies": {
+    "object-equal": "^1.0.0"
   }
 }

--- a/src/Initable.js
+++ b/src/Initable.js
@@ -1,6 +1,7 @@
 import PropTypes from 'prop-types'
 import { PureComponent, createElement } from 'react'
 import hoistStatics from 'hoist-non-react-statics'
+import isEqual from 'object-equal'
 
 import getDisplayName from './getDisplayName'
 
@@ -31,6 +32,11 @@ function Initable({ loadFn, loadingFn, unloadFn, reloadFn }) {
         this.subscriber()
       }
       componentWillReceiveProps(props) {
+        // this check is to ensure props DO changed.
+        if (isEqual(this.props, props)) {
+          return
+        }
+
         if (reloadFn) {
           this._store.dispatch(reloadFn(this._store.getState(), this.props, props))
         } else {
@@ -40,7 +46,7 @@ function Initable({ loadFn, loadingFn, unloadFn, reloadFn }) {
       }
 
       onChangeState = () => {
-        this.setState({}) // NOTE: Only for triggering update
+        this.forceUpdate() // NOTE: Only for triggering update
       }
 
       render() {

--- a/test/initable.test.js
+++ b/test/initable.test.js
@@ -178,7 +178,7 @@ test('it should call unloadFn & loadFn in order if reloadFn is not provided when
   }).not.toThrow()
 })
 
-test('it should call reloadFn if provided when received new props', () => {
+test('it should call reloadFn if provided when received new props, but should NOT call reloadFn when received the same props', () => {
   const store = createDummyStore()
   const reloadFn = jest.fn(dummyReloadFn)
   const loadFn = jest.fn(dummyLoadFn)
@@ -206,8 +206,16 @@ test('it should call reloadFn if provided when received new props', () => {
       <Wrapped1 {...newProps} />
     </Provider>
   )
+  // call update twice with the same props to simulate `componentWillReceiveProps`
+  // with same props
+  renderer.update(
+    <Provider store={store}>
+      <Wrapped1 {...newProps} />
+    </Provider>
+  )
 
   expect(reloadFn).toBeCalledWith(store.getState(), oldProps, newProps)
+  expect(reloadFn).toHaveBeenCalledTimes(1)
   expect(loadFn).toHaveBeenCalledTimes(1)
   expect(unloadFn).not.toBeCalled()
 })

--- a/yarn.lock
+++ b/yarn.lock
@@ -2288,6 +2288,10 @@ object-assign@^4.1.0, object-assign@^4.1.1:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/object-assign/-/object-assign-4.1.1.tgz#2109adc7965887cfc05cbbd442cac8bfbb360863"
 
+object-equal@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/object-equal/-/object-equal-1.0.0.tgz#9201d569f789182956f82c806818e35a27a2f117"
+
 object-inspect@~1.3.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/object-inspect/-/object-inspect-1.3.0.tgz#5b1eb8e6742e2ee83342a637034d844928ba2f6d"


### PR DESCRIPTION
- the reload phase is trigger unexpectedly when
componentWillReceiveProps is called with a new props object with the
same value.
- when rerendering, I should call forceUpdate instead of setState({})
because the shouldComponentUpdate check will prevent component from
rerendering.